### PR TITLE
Update README and fix task prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ For USACO, you will need to download and extract the USACO dataset. This can be 
 ### [CORE-bench](https://github.com/siegelz/core-bench)
 - Computational reproducibility benchmark for agents on real scientific papers
 - Supports fully parallelized evaluation on Azure VMs
-- For detailed instructions on running CORE-bench evaluations, see the [CORE-bench repository](https://github.com/CORE-Bench/CORE-Bench)
 
 ### [tau-bench](https://github.com/tau-bench/tau-bench)
 - Benchmark for Tool-Agent-User Interaction in real-world domains
@@ -221,7 +220,7 @@ gpg --output hal/benchmarks/corebench/core_test.json --decrypt hal/benchmarks/co
 hal-eval --benchmark corebench_easy \
   --agent_dir agents/list_files_agent \
   --agent_function main.run \
-  --agent_name "Test Agent" \
+  --agent_name "Test Agent"
 ```
 
 ## How Do I Run Evaluations?

--- a/hal/benchmarks/corebench.py
+++ b/hal/benchmarks/corebench.py
@@ -318,7 +318,7 @@ class CoreBenchEasy(CoreBench):
             The constructed prompt string
         """
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_easy\n\nYour goal is to answer questions about the output of scientific code. You should read through the files in the `environment/results` directory to answer the following questions: {json_fields}. Save your answers to a file named report.json in the base directory whose keys are the questions and values are the answers. **You should not actually run or execute any code.** All answers can be obtained by reading through the results directory."
+        return f"Task: codeocean_easy\n\nYour goal is to answer questions about the output of scientific code. You should read through the files in the `environment/results` directory to answer the following questions: {json_fields}. Your submitted answer should be a Python dictionary whose keys are exactly those questions and values are the answers. **You should not actually run or execute any code.** All answers can be obtained by reading through the results directory."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """
@@ -354,7 +354,7 @@ class CoreBenchMedium(CoreBench):
         """
         task_prompt = task["task_prompt"]
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_medium\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the base directory where you fill in all of the following fields: {json_fields}. You should read the instructions on how to reproduce the capsule in REPRODUCING.md."
+        return f"Task: codeocean_medium\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt} to answer the following questions: {json_fields}. Your submitted answer should be a Python dictionary whose keys are exactly those questions and values are the answers. You should read the instructions on how to reproduce the capsule in REPRODUCING.md."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """
@@ -405,7 +405,7 @@ class CoreBenchHard(CoreBench):
         """
         task_prompt = task["task_prompt"]
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_hard\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the base directory where you fill in all of the following fields: {json_fields}. You should install all of the requirements found in the Readme file and then run the commands necessary to answer the questions."
+        return f"Task: codeocean_hard\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt} to answer the following questions: {json_fields}. Your submitted answer should be a Python dictionary whose keys are exactly those questions and values are the answers. You should install all of the requirements found in the Readme file and then run the commands necessary to answer the questions."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """

--- a/hal/benchmarks/corebench.py
+++ b/hal/benchmarks/corebench.py
@@ -318,7 +318,7 @@ class CoreBenchEasy(CoreBench):
             The constructed prompt string
         """
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_easy\n\nYour goal is to answer questions about the output of scientific code. You should read through the files in the `results` directory to answer the following questions: {json_fields}. Save your answers to a file named report.json in the environment directory you started in that contains the capsule directory itself whose keys are the questions and values are the answers. **You should not actually run or execute any code.** All answers can be obtained by reading through the results directory."
+        return f"Task: codeocean_easy\n\nYour goal is to answer questions about the output of scientific code. You should read through the files in the `environment/results` directory to answer the following questions: {json_fields}. Save your answers to a file named report.json in the base directory whose keys are the questions and values are the answers. **You should not actually run or execute any code.** All answers can be obtained by reading through the results directory."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """
@@ -354,7 +354,7 @@ class CoreBenchMedium(CoreBench):
         """
         task_prompt = task["task_prompt"]
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_medium\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the environment directory you started in that contains the capsule itself, where you fill in all of the following fields: {json_fields}. You should read the instructions on how to reproduce the capsule in REPRODUCING.md."
+        return f"Task: codeocean_medium\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the base directory where you fill in all of the following fields: {json_fields}. You should read the instructions on how to reproduce the capsule in REPRODUCING.md."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """
@@ -405,7 +405,7 @@ class CoreBenchHard(CoreBench):
         """
         task_prompt = task["task_prompt"]
         json_fields = str(task["results"][0].keys())
-        return f"Task: codeocean_hard\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the environment directory you started in that contains the capsule itself, where you fill in all of the following fields: {json_fields}. You should install all of the requirements found in the Readme file and then run the commands necessary to answer the questions."
+        return f"Task: codeocean_hard\n\nYour goal is to test the computational reproducibility of the repository cloned to your current directory, which is code from a scientific paper. Specifically, you need to {task_prompt}. Save your report to a file named report.json in the base directory where you fill in all of the following fields: {json_fields}. You should install all of the requirements found in the Readme file and then run the commands necessary to answer the questions."
     
     def _get_capsule_files_dict(self, capsule_dir: str) -> Dict[str, str]:
         """


### PR DESCRIPTION
Enhance the README for CORE-bench with clearer instructions and correct the task prompts to specify the appropriate directories for saving reports.