### PR TITLE
31 core bench scoring code fails

### DIFF
--- a/agents/list_files_agent/main.py
+++ b/agents/list_files_agent/main.py
@@ -23,5 +23,4 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
             print(os.path.join(root, file))
     
     # Return empty patches since we're just listing files
-    # return {instance_id: "{\"Report the accuracy of the multitask learning model at the end of training on the test set.\": 96.12499135323452}" for instance_id in input.keys()}
-    return {instance_id: "Sample answer" for instance_id in input.keys()}
+    return {instance_id: {"Report the accuracy of the multitask learning model at the end of training on the test set.": 96.12499135323452} for instance_id in input.keys()}

--- a/hal/benchmarks/corebench.py
+++ b/hal/benchmarks/corebench.py
@@ -170,7 +170,12 @@ class CoreBench(BaseBenchmark):
                 gt_result = self.benchmark_answers[task_id]
                 
                 # Parse the agent's answer as a dictionary
-                reported_result = json.loads(solution)
+                if type(solution) is str:
+                    reported_result = json.loads(solution)
+                elif type(solution) is dict:
+                    reported_result = solution
+                else:
+                    raise ValueError(f"Invalid solution format for task {task_id}: {solution}")
                 
                 # Evaluate the result using the prediction interval logic
                 evaluation = self.__eval_result_json(gt_result, reported_result)


### PR DESCRIPTION
Allows the agent to return a non-string JSON as the answer, instead of a string JSON.