### PR TITLE
Add github repo information to track benchmark version

### DIFF
--- a/hal/benchmarks/base_benchmark.py
+++ b/hal/benchmarks/base_benchmark.py
@@ -3,11 +3,59 @@ from typing import Dict, Any, Optional, TypeVar, Generic
 from pydantic import BaseModel, TypeAdapter
 import json
 import os
+import subprocess
 from inspect_ai.log import EvalLog, write_eval_log
 from datetime import datetime
 from ..utils.weave_utils import get_total_cost, get_weave_calls
 from ..utils.logging_utils import print_warning
 from ..utils.utils import make_json_serializable
+
+
+def get_git_info() -> Dict[str, str]:
+    """Get git repository information."""
+    git_info = {}
+    
+    try:
+        # Get current commit hash
+        git_commit = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], 
+            stderr=subprocess.DEVNULL
+        ).decode('utf-8').strip()
+        git_info['commit'] = git_commit
+        
+        # Get repository URL
+        git_remote_url = subprocess.check_output(
+            ['git', 'config', '--get', 'remote.origin.url'],
+            stderr=subprocess.DEVNULL
+        ).decode('utf-8').strip()
+        git_info['repository_url'] = git_remote_url
+        
+        # Get current branch
+        git_branch = subprocess.check_output(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            stderr=subprocess.DEVNULL
+        ).decode('utf-8').strip()
+        git_info['branch'] = git_branch
+        
+        # Get commit timestamp
+        git_commit_time = subprocess.check_output(
+            ['git', 'show', '-s', '--format=%ci', 'HEAD'],
+            stderr=subprocess.DEVNULL
+        ).decode('utf-8').strip()
+        git_info['commit_timestamp'] = git_commit_time
+        
+        # Build repository URL with commit
+        if 'github.com' in git_remote_url:
+            # Format GitHub URL to point to specific commit
+            repo_base = git_remote_url.replace('.git', '').replace('git@github.com:', 'https://github.com/')
+            if repo_base.endswith('/'):
+                repo_base = repo_base[:-1]
+            git_info['commit_url'] = f"{repo_base}/tree/{git_commit}"
+        
+    except subprocess.SubprocessError:
+        git_info['error'] = "Failed to get git information"
+    
+    return git_info
 
 
 class BaseBenchmark(ABC):
@@ -87,6 +135,7 @@ class BaseBenchmark(ABC):
             "raw_logging_results": raw_logging,
             "total_usage": total_usage,
             'total_cost': total_cost,
+            "git_info": get_git_info()
         }
         
         # Save full results


### PR DESCRIPTION
To solve https://github.com/princeton-pli/hal-harness/issues/41

Tested using a small SWE-Bench Verified Mini run; this key was added to the UPLOAD json file:

"git_info": {
    "commit": "a789f02a883e748ea1c1afb4620c8b76ce9e9a76",
    "repository_url": "https://github.com/benediktstroebl/hal-harness.git",
    "branch": "main",
    "commit_timestamp": "2025-04-09 21:12:57 +0000",
    "commit_url": "https://github.com/benediktstroebl/hal-harness/tree/a789f02a883e748ea1c1afb4620c8b76ce9e9a76"
  }