### PR TITLE
Update task timeout in `docker_runner.py` to 7200 seconds

### DIFF
--- a/hal/utils/docker_runner.py
+++ b/hal/utils/docker_runner.py
@@ -189,7 +189,7 @@ class DockerRunner:
                              agent_dir: str,
                              agent_args: Dict[str, Any],
                              run_id: str,
-                             timeout: int = 900) -> Optional[Dict[str, Any]]:
+                             timeout: int = 7200) -> Optional[Dict[str, Any]]:
         """Process a single task in a Docker container with timeout"""
         # Create temporary directory for mounting into container
         temp_dir = Path(tempfile.mkdtemp())


### PR DESCRIPTION
Increase the timeout for processing a single task in a Docker container from 900 seconds to 7200 seconds.

This makes it consistent with the timeout used in `vm_runner.py`.