### PR TITLE
Implement hal-test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ The harness uses a command-line interface (CLI) to run evaluations. The basic co
 hal-eval --benchmark <benchmark_name> --agent_dir <agent_directory> --agent_function <agent_function> --agent_name <agent_name> [OPTIONS]
 ```
 
+For a quick sanity check of the built-in generalist agent you can use the `hal-test` command. This runs the generalist agent on a small subset of tasks from a benchmark:
+
+```bash
+hal-test --benchmark gaia -A model_name=gpt-3.5-turbo -A budget=0.01 --max_tasks 1
+```
+
+The command accepts the same argument syntax as `hal-eval` but is intended for lightweight validation.
+
 ### Core Options
 
 *   **`--benchmark <benchmark_name>`**: The name of the benchmark to run. Supported benchmarks:

--- a/hal/generalist_cli.py
+++ b/hal/generalist_cli.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import asyncio
+from pathlib import Path
+import click
+import yaml
+
+
+def parse_cli_args(args: tuple[str] | list[str] | None):
+    """Parse CLI arguments into a dictionary."""
+    params: dict[str, any] = {}
+    if args:
+        for arg in list(args):
+            parts = arg.split("=", 1)
+            if len(parts) > 1:
+                key = parts[0].replace("-", "_")
+                value = parts[1]
+                try:
+                    parsed_value = yaml.safe_load(value)
+                    if isinstance(parsed_value, str):
+                        if "," in value:
+                            parsed_value = value.split(",")
+                        elif value.lower() in ["true", "false"]:
+                            parsed_value = value.lower() == "true"
+                        elif value.lower() in ["none", "null", "nan"]:
+                            parsed_value = None
+                        else:
+                            try:
+                                parsed_value = int(value)
+                            except ValueError:
+                                try:
+                                    parsed_value = float(value)
+                                except ValueError:
+                                    parsed_value = value
+                    params[key] = parsed_value
+                except yaml.YAMLError:
+                    params[key] = value
+    return params
+from .utils.logging_utils import (
+    setup_logging,
+    print_header,
+    print_step,
+    print_success,
+    log_results_table,
+)
+
+
+@click.command(help="Run the HAL generalist agent on a benchmark for quick testing.")
+@click.option("--benchmark", required=True, help="Benchmark name to test")
+@click.option("-A", "a", multiple=True, type=str, help="Args to pass to the agent")
+@click.option("-B", "b", multiple=True, type=str, help="Args to pass to the benchmark")
+@click.option("--max_tasks", default=1, show_default=True, help="Number of tasks to run")
+def main(benchmark: str, a: tuple[str], b: tuple[str], max_tasks: int) -> None:
+    """Entry point for hal-test CLI."""
+    agent_args = parse_cli_args(a)
+    benchmark_args = parse_cli_args(b)
+
+    config_path = Path(__file__).with_name("config.yaml")
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    agent_dir = Path(__file__).resolve().parent.parent / "agents" / "hal_generalist_agent"
+    run_command = " ".join(["hal-test"] + sys.argv[1:])
+    run_id = f"test_{benchmark}"
+
+    log_dir = os.path.join("results", benchmark, run_id)
+    os.makedirs(log_dir, exist_ok=True)
+    setup_logging(log_dir, run_id)
+
+
+    from .agent_runner import AgentRunner
+
+    print_header("HAL Harness Test")
+    print_step(f"Benchmark: {benchmark}")
+
+    runner = AgentRunner(
+        agent_function="main.run",
+        agent_dir=str(agent_dir),
+        agent_args={**agent_args, **benchmark_args},
+        benchmark_name=benchmark,
+        config=config,
+        run_id=run_id,
+        max_concurrent=1,
+        run_command=run_command,
+        ignore_errors=False,
+        max_tasks=max_tasks,
+    )
+
+    results = asyncio.run(runner.run(agent_name="hal_generalist_agent"))
+    print_success("Test run completed")
+    log_results_table(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ open_deep_research = [
 hal-eval = "hal.cli:main"
 hal-upload = "hal.utils.upload:upload_results"
 hal-decrypt = "hal.utils.decrypt:decrypt_cli"
+hal-test = "hal.generalist_cli:main"
 
 [tool.setuptools]
 packages = ["hal"]

--- a/tests/test_hal_test_cli.py
+++ b/tests/test_hal_test_cli.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+import pytest
+
+import sys
+import types
+
+sys.modules.setdefault(
+    "weave",
+    types.SimpleNamespace(
+        init=lambda x: None,
+        finish=lambda: None,
+        op=lambda *a, **k: (lambda func: func),
+    ),
+)
+
+inspect_ai_mod = types.ModuleType("inspect_ai")
+inspect_ai_mod.eval = lambda *a, **k: None
+inspect_ai_mod.TaskInfo = object
+inspect_ai_mod.solver = types.SimpleNamespace(Solver=object)
+sys.modules.setdefault("inspect_ai", inspect_ai_mod)
+sys.modules.setdefault(
+    "inspect_ai.solver",
+    types.SimpleNamespace(solver=lambda *a, **k: None, Solver=object),
+)
+
+sys.modules.setdefault(
+    "inspect_ai.log",
+    types.SimpleNamespace(EvalLog=dict, write_eval_log=lambda *a, **k: None),
+)
+sys.modules.setdefault("inspect_ai.model", types.SimpleNamespace(get_model=lambda *a, **k: None))
+
+eval_mod = types.ModuleType("inspect_ai._eval")
+eval_mod.loader = types.SimpleNamespace(load_tasks=lambda *a, **k: [])
+eval_mod.loader_utils = types.SimpleNamespace(task_from_str=lambda *a, **k: None)
+sys.modules.setdefault("inspect_ai._eval", eval_mod)
+sys.modules.setdefault("inspect_ai._eval.loader", eval_mod.loader)
+
+from hal.generalist_cli import main as hal_test
+
+class DummyRunner:
+    def __init__(self, *args, **kwargs):
+        self.benchmark = SimpleNamespace(benchmark_name=kwargs.get("benchmark_name"), get_run_dir=lambda run_id: ".")
+    async def run(self, agent_name: str, upload: bool = False):
+        return {"accuracy": 1.0}
+
+
+def test_hal_test_cli_invokes_runner(monkeypatch):
+    dummy_mod = types.ModuleType("hal.agent_runner")
+    dummy_mod.AgentRunner = DummyRunner
+    monkeypatch.setitem(sys.modules, "hal.agent_runner", dummy_mod)
+    monkeypatch.setattr("hal.utils.logging_utils.setup_logging", lambda *a, **k: None)
+    result = hal_test.main(
+        [
+            "--benchmark",
+            "gaia",
+            "-A",
+            "model_name=dummy",
+            "-A",
+            "budget=0.01",
+            "--max_tasks",
+            "1",
+        ],
+        standalone_mode=False,
+    )
+    assert result is None


### PR DESCRIPTION
## Summary
- add new command `hal-test` for quick validation
- document the new command in README
- test the CLI with a dummy runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bdb2336883289fe393b0f4eec4c4