### PR TITLE
Add OpenRouter support with reasoning parameters

### DIFF
--- a/agents/hal_generalist_agent/main.py
+++ b/agents/hal_generalist_agent/main.py
@@ -479,8 +479,21 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     litellm.drop_params = True
     model_params = {}
     model_params['model_id'] = kwargs['model_name']
+    
+    # Handle reasoning parameters based on provider
     if 'reasoning_effort' in kwargs:
-        model_params['reasoning_effort'] = kwargs['reasoning_effort']
+        if 'openrouter/' in kwargs['model_name']:
+            # OpenRouter doesn't support reasoning_effort, convert to reasoning.max_tokens
+            effort_to_tokens = {
+                'low': 1024,
+                'medium': 2048,
+                'high': 4096
+            }
+            model_params['reasoning'] = {"max_tokens": effort_to_tokens.get(kwargs['reasoning_effort'], 4096)}
+        else:
+            # For Anthropic direct and other providers that support reasoning_effort
+            model_params['reasoning_effort'] = kwargs['reasoning_effort']
+    
     if 'temperature' in kwargs:
         model_params['temperature'] = kwargs['temperature']
         

--- a/hal/utils/weave_utils.py
+++ b/hal/utils/weave_utils.py
@@ -41,6 +41,9 @@ MODEL_PRICES_DICT = {
                 "claude-3-5-sonnet-20240620": {"prompt_tokens": 3/1e6, "completion_tokens": 15/1e6},
                 "claude-3-5-sonnet-20241022": {"prompt_tokens": 3/1e6, "completion_tokens": 15/1e6},
                 "claude-opus-4-20250514": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "claude-opus-4": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "anthropic/claude-opus-4": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "anthropic/claude-opus-4-20250514": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
                 "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {"prompt_tokens": 3/1e6, "completion_tokens": 15/1e6},
                 "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {"prompt_tokens": 3/1e6, "completion_tokens": 15/1e6},
                 "openai/gpt-4o-2024-11-20": {"prompt_tokens": 2.5/1e6, "completion_tokens": 10/1e6},
@@ -89,6 +92,15 @@ MODEL_PRICES_DICT = {
                 "gemini/gemini-2.5-pro-preview-03-25": {"prompt_tokens": 1.25/1e6, "completion_tokens": 10/1e6},
                 "gemini-2.5-pro-preview-03-25": {"prompt_tokens": 1.25/1e6, "completion_tokens": 10/1e6},
                 "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt_tokens": 0.27/1e6, "completion_tokens": 0.85/1e6},
+                "openrouter/anthropic/claude-opus-4": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "openrouter/anthropic/claude-opus-4-20250514": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "openrouter/anthropic/claude-opus-4.1": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "openrouter/anthropic/claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "openrouter/anthropic/claude-sonnet-4": {"prompt_tokens": 3/1e6, "completion_tokens": 15/1e6},
+                "anthropic/claude-opus-4.1": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "anthropic/claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "claude-opus-4.1": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
 }
 
 def fetch_weave_calls(client) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Adds support for OpenRouter models with reasoning parameters across HAL agents
- Implements proper parameter translation for OpenRouter's API requirements
- Fixes provider detection order to handle OpenRouter models correctly

## Changes
1. **HAL Generalist Agent**: Added reasoning parameter translation that converts `reasoning_effort` to `reasoning.max_tokens` for OpenRouter models
2. **TauBench Fewshot Agent**: 
   - Fixed provider detection order (OpenRouter must be checked before other providers)
   - Implemented completion wrappers to inject reasoning parameters via `extra_body`
   - Added temperature=1.0 for all reasoning calls
3. **Model Pricing**: Added comprehensive pricing entries for Claude Opus 4/4.1 variants including OpenRouter versions

## Test Plan
- [x] Test HAL generalist agent with OpenRouter models
- [x] Test TauBench fewshot agent with OpenRouter models
- [x] Verify reasoning parameters are correctly passed
- [x] Ensure non-OpenRouter models still work correctly