### PR TITLE
Fix GPT-5 support in HAL generalist agent

### DIFF
--- a/agents/hal_generalist_agent/main.py
+++ b/agents/hal_generalist_agent/main.py
@@ -18,6 +18,24 @@ from smolagents import CodeAgent, tool, LiteLLMModel, DuckDuckGoSearchTool, Code
 from smolagents.models import MessageRole, Model
 from smolagents.agents import ActionStep
 
+# Monkey-patch smolagents to handle GPT-5
+import smolagents.models
+import re
+
+def supports_stop_parameter(model_id: str) -> bool:
+    """
+    Check if the model supports the `stop` parameter.
+    
+    Not supported with reasoning models openai/o3, openai/o4-mini, and gpt-5 (and their versioned variants).
+    """
+    model_name = model_id.split("/")[-1]
+    # o3, o4-mini, and gpt-5 (including versioned variants) don't support stop parameter
+    pattern = r"^(o3[-\d]*|o4-mini[-\d]*|gpt-5[-\d]*)$"
+    return not re.match(pattern, model_name)
+
+# Replace the function in smolagents
+smolagents.models.supports_stop_parameter = supports_stop_parameter
+
 from mdconvert import MarkdownConverter
 
 AUTHORIZED_IMPORTS = [

--- a/hal/utils/weave_utils.py
+++ b/hal/utils/weave_utils.py
@@ -101,6 +101,7 @@ MODEL_PRICES_DICT = {
                 "anthropic/claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
                 "claude-opus-4.1": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
                 "claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
+                "gpt-5": {"prompt_tokens": 1.25/1e6, "completion_tokens": 10/1e6},
 }
 
 def fetch_weave_calls(client) -> List[Dict[str, Any]]:

--- a/hal/utils/weave_utils.py
+++ b/hal/utils/weave_utils.py
@@ -102,6 +102,7 @@ MODEL_PRICES_DICT = {
                 "claude-opus-4.1": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
                 "claude-opus-4.1-20250805": {"prompt_tokens": 15/1e6, "completion_tokens": 75/1e6},
                 "gpt-5": {"prompt_tokens": 1.25/1e6, "completion_tokens": 10/1e6},
+                "gpt-5-2025-08-07": {"prompt_tokens": 1.25/1e6, "completion_tokens": 10/1e6},
 }
 
 def fetch_weave_calls(client) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Add monkey-patch to handle GPT-5's lack of stop parameter support in smolagents
- Update regex pattern to include gpt-5 alongside o3 and o4-mini models  
- Add GPT-5 pricing to model_prices_dict

## Details
This PR fixes a BadRequestError that occurs when using GPT-5 with the HAL generalist agent. The error was caused by smolagents attempting to pass a `stop` parameter to GPT-5, which doesn't support it.

The fix involves monkey-patching the `supports_stop_parameter` function in smolagents to include gpt-5 in the list of models that don't support the stop parameter, alongside o3 and o4-mini models.

## Test plan
- Run HAL generalist agent with GPT-5 model
- Verify no BadRequestError occurs
- Confirm agent functions correctly without stop parameter