### PR TITLE
chore: Update link to tau-bench repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can also convert HAL experiment outputs to AppWorld experiment outputs (via 
 - Computational reproducibility benchmark for agents on real scientific papers
 - Supports fully parallelized evaluation on Azure VMs
 
-### [tau-bench](https://github.com/tau-bench/tau-bench)
+### [tau-bench](https://github.com/sierra-research/tau-bench)
 - Install benchmark specific dependencies:
 ```bash
 pip install -e .[taubench]


### PR DESCRIPTION
Another `README.md` link update - this time pointing to an empty repository for tau-bench.

This PR updates the link to point to [the active tau-bench repo](https://github.com/sierra-research/tau-bench).