### PR TITLE
chore: use setuptools package discovery to make hal-harness installable via pip.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,5 +135,4 @@ hal-upload = "hal.utils.upload:upload_results"
 hal-decrypt = "hal.utils.decrypt:decrypt_cli"
 
 [tool.setuptools.packages.find]
-where = ["."]
-exclude = ["test*"]
+where = ["hal"]


### PR DESCRIPTION
As currently configured, a non-editable install of `hal-harness` does not include any submodules underneath the top-level `hal` module.

This is because `pyproject.toml` concretely points to _only_ `packages = ["hal"]`.

This PR replaces this config with setuptools's automated package discovery. Read more [here](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html). 