### PR TITLE
Fix litellm.BadRequestError

### DIFF
--- a/agents/core_agent/main.py
+++ b/agents/core_agent/main.py
@@ -24,8 +24,8 @@ def supports_stop_parameter(model_id: str) -> bool:
     Not supported with reasoning models openai/o3, openai/o4-mini, and gpt-5 (and their versioned variants).
     """
     model_name = model_id.split("/")[-1]
-    # o3, o4-mini, and gpt-5 (including versioned variants) don't support stop parameter
-    pattern = r"^(o3[-\d]*|o4-mini[-\d]*|gpt-5[-\d]*)$"
+    # o3, o4-mini, and gpt-5 (including all variants like gpt-5-mini) don't support stop parameter
+    pattern = r"^(o3[-\d]*|o4-mini[-\d]*|gpt-5.*)$"
     return not re.match(pattern, model_name)
 
 # Replace the function in smolagents


### PR DESCRIPTION

This PR fixes a `litellm.BadRequestError` caused by passing the unsupported stop parameter to gpt-5 models.

Although there is existing logic to disable stop for unsupported models, a regex bug caused gpt-5 variants (e.g. gpt-5-mini) to be missed. The previous pattern (gpt-5[-\d]*) only matched hyphens and digits, so model names containing letters were not excluded correctly.

This PR updates the regex to properly match all gpt-5 variants, ensuring the stop parameter is not sent to any unsupported gpt-5 model.