### PR TITLE
Use response API for openai provider

### DIFF
--- a/agents/taubench_example_agent/main.py
+++ b/agents/taubench_example_agent/main.py
@@ -4,6 +4,26 @@ from tau_bench.types import Action
 from openai import OpenAI
 
 
+def _extract_response_text(response) -> str:
+    """Best-effort text extraction for OpenAI Responses API outputs."""
+    if getattr(response, "output_text", None):
+        return response.output_text.strip()
+
+    output_items = getattr(response, "output", []) or []
+    text_chunks: list[str] = []
+    for item in output_items:
+        if getattr(item, "type", None) != "message":
+            continue
+        for content in getattr(item, "content", []) or []:
+            if (
+                getattr(content, "type", None) == "output_text"
+                and getattr(content, "text", None)
+            ):
+                text_chunks.append(content.text)
+
+    return "".join(text_chunks).strip()
+
+
 def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     assert "model_name" in kwargs, "model_name is required"
     client = OpenAI()
@@ -22,18 +42,22 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     instruction = isolated_env.reset(input[task_id]["task_index"]).observation
 
     ### YOUR AGENT CODE HERE ###
-    response = client.chat.completions.create(
-        model=kwargs["model_name"],
-        messages=[
+    request_kwargs = {
+        "model": kwargs["model_name"],
+        "input": [
             {"role": "user", "content": instruction},
         ],
-        max_tokens=2000,
-        n=1,
-        temperature=1,
-    )
+        "max_output_tokens": 2000,
+        "temperature": 1,
+    }
+    if "reasoning_effort" in kwargs:
+        request_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
+
+    response = client.responses.create(**request_kwargs)
 
     ### ACTION ###
-    action = Action(name=response.choices[0].message.content, kwargs={})
+    action_text = _extract_response_text(response)
+    action = Action(name=action_text, kwargs={})
     response = isolated_env.step(action)
 
     ### WHEN DONE WE RETURN THE ENV STATE ###

--- a/agents/taubench_example_agent/main.py
+++ b/agents/taubench_example_agent/main.py
@@ -5,22 +5,8 @@ from openai import OpenAI
 
 
 def _extract_response_text(response) -> str:
-    """Best-effort text extraction for OpenAI Responses API outputs."""
-    if getattr(response, "output_text", None):
-        return response.output_text.strip()
-
-    output_items = getattr(response, "output", []) or []
-    text_chunks: list[str] = []
-    for item in output_items:
-        if getattr(item, "type", None) != "message":
-            continue
-        for content in getattr(item, "content", []) or []:
-            if getattr(content, "type", None) == "output_text" and getattr(
-                content, "text", None
-            ):
-                text_chunks.append(content.text)
-
-    return "".join(text_chunks).strip()
+    """Extract text from an OpenAI Responses API response."""
+    return response.output_text.strip()
 
 
 def run(input: dict[str, dict], **kwargs) -> dict[str, str]:

--- a/agents/taubench_example_agent/main.py
+++ b/agents/taubench_example_agent/main.py
@@ -15,9 +15,8 @@ def _extract_response_text(response) -> str:
         if getattr(item, "type", None) != "message":
             continue
         for content in getattr(item, "content", []) or []:
-            if (
-                getattr(content, "type", None) == "output_text"
-                and getattr(content, "text", None)
+            if getattr(content, "type", None) == "output_text" and getattr(
+                content, "text", None
             ):
                 text_chunks.append(content.text)
 

--- a/agents/taubench_few_shot/few_shot.py
+++ b/agents/taubench_few_shot/few_shot.py
@@ -14,92 +14,7 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     def _responses_model_name(model: str) -> str:
         return model if model.startswith("responses/") else f"responses/{model}"
 
-    # Initialize values used by the completion wrappers.
     model_name = kwargs["model_name"]
-    is_native_openai = False
-
-    # Store the original completion functions
-    original_completion = litellm.completion
-    original_acompletion = litellm.acompletion
-
-    # Create a wrapper that adds reasoning parameters only for the agent's model
-    def completion_with_reasoning(*args, **completion_kwargs):
-        # Check if this is a call with our agent's model
-        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
-            if "reasoning_effort" in kwargs:
-                # Set temperature to 1 for reasoning calls
-                completion_kwargs["temperature"] = 1.0
-
-                if "openrouter/" in kwargs["model_name"]:
-                    # For OpenRouter, add reasoning to extra_body
-                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
-                    reasoning_tokens = effort_to_tokens.get(
-                        kwargs["reasoning_effort"], 4096
-                    )
-                    extra_body = completion_kwargs.get("extra_body", {})
-                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
-                    extra_body["include_reasoning"] = True
-                    completion_kwargs["extra_body"] = extra_body
-                    print(
-                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
-                    )
-                elif is_native_openai:
-                    completion_kwargs["reasoning"] = {
-                        "effort": kwargs["reasoning_effort"]
-                    }
-                    completion_kwargs.pop("reasoning_effort", None)
-                    print(
-                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-                else:
-                    # For direct Anthropic
-                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
-                    print(
-                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-
-        # Call the original function
-        return original_completion(*args, **completion_kwargs)
-
-    # Create async wrapper
-    async def acompletion_with_reasoning(*args, **completion_kwargs):
-        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
-            if "reasoning_effort" in kwargs:
-                # Set temperature to 1 for reasoning calls
-                completion_kwargs["temperature"] = 1.0
-
-                if "openrouter/" in kwargs["model_name"]:
-                    # For OpenRouter, add reasoning to extra_body
-                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
-                    reasoning_tokens = effort_to_tokens.get(
-                        kwargs["reasoning_effort"], 4096
-                    )
-                    extra_body = completion_kwargs.get("extra_body", {})
-                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
-                    extra_body["include_reasoning"] = True
-                    completion_kwargs["extra_body"] = extra_body
-                    print(
-                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
-                    )
-                elif is_native_openai:
-                    completion_kwargs["reasoning"] = {
-                        "effort": kwargs["reasoning_effort"]
-                    }
-                    completion_kwargs.pop("reasoning_effort", None)
-                    print(
-                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-                else:
-                    # For direct Anthropic
-                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
-                    print(
-                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-        return await original_acompletion(*args, **completion_kwargs)
-
-    # Replace both sync and async completion functions
-    litellm.completion = completion_with_reasoning
-    litellm.acompletion = acompletion_with_reasoning
 
     # Separate providers for user simulation vs agent
     # User simulation needs OpenAI-compatible API (for tau-bench internals)
@@ -138,6 +53,87 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     is_native_openai = agent_provider == "openai" and api_base is None
     if is_native_openai:
         model_name = _responses_model_name(model_name)
+
+    # Store the original completion functions
+    original_completion = litellm.completion
+    original_acompletion = litellm.acompletion
+
+    # Create wrappers that add reasoning parameters only for the agent's model.
+    # is_native_openai is bound via default arg so it's an explicit input,
+    # not silently inherited from scope.
+    def completion_with_reasoning(
+        *args, _is_native_openai=is_native_openai, **completion_kwargs
+    ):
+        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
+            if "reasoning_effort" in kwargs:
+                completion_kwargs["temperature"] = 1.0
+
+                if "openrouter/" in kwargs["model_name"]:
+                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
+                    reasoning_tokens = effort_to_tokens.get(
+                        kwargs["reasoning_effort"], 4096
+                    )
+                    extra_body = completion_kwargs.get("extra_body", {})
+                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
+                    extra_body["include_reasoning"] = True
+                    completion_kwargs["extra_body"] = extra_body
+                    print(
+                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
+                    )
+                elif _is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
+                else:
+                    # For direct Anthropic
+                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
+                    print(
+                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
+
+        return original_completion(*args, **completion_kwargs)
+
+    async def acompletion_with_reasoning(
+        *args, _is_native_openai=is_native_openai, **completion_kwargs
+    ):
+        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
+            if "reasoning_effort" in kwargs:
+                completion_kwargs["temperature"] = 1.0
+
+                if "openrouter/" in kwargs["model_name"]:
+                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
+                    reasoning_tokens = effort_to_tokens.get(
+                        kwargs["reasoning_effort"], 4096
+                    )
+                    extra_body = completion_kwargs.get("extra_body", {})
+                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
+                    extra_body["include_reasoning"] = True
+                    completion_kwargs["extra_body"] = extra_body
+                    print(
+                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
+                    )
+                elif _is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
+                else:
+                    # For direct Anthropic
+                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
+                    print(
+                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
+        return await original_acompletion(*args, **completion_kwargs)
+
+    litellm.completion = completion_with_reasoning
+    litellm.acompletion = acompletion_with_reasoning
 
     from tau_bench.envs import get_env
     from tau_bench.agents.few_shot_agent import FewShotToolCallingAgent

--- a/agents/taubench_few_shot/few_shot.py
+++ b/agents/taubench_few_shot/few_shot.py
@@ -1,5 +1,59 @@
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
+
+_EFFORT_TO_TOKENS = {"low": 1024, "medium": 2048, "high": 4096}
+
+
+def _inject_reasoning_kwargs(
+    completion_kwargs: dict,
+    *,
+    model_name: str,
+    reasoning_effort: str | None,
+    is_openrouter: bool,
+    is_native_openai: bool,
+) -> None:
+    """Inject reasoning parameters into litellm completion kwargs in-place.
+
+    Handles three provider branches: OpenRouter, native OpenAI, and
+    Anthropic/other.  Only modifies kwargs when the call targets our agent
+    model and a reasoning_effort was requested.
+    """
+    if reasoning_effort is None:
+        return
+    if completion_kwargs.get("model") != model_name:
+        return
+
+    completion_kwargs["temperature"] = 1.0
+
+    if is_openrouter:
+        reasoning_tokens = _EFFORT_TO_TOKENS.get(reasoning_effort, 4096)
+        extra_body = completion_kwargs.get("extra_body", {})
+        extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
+        extra_body["include_reasoning"] = True
+        completion_kwargs["extra_body"] = extra_body
+        logger.warning(
+            "Injecting reasoning max_tokens=%d for OpenRouter model %s",
+            reasoning_tokens,
+            model_name,
+        )
+    elif is_native_openai:
+        completion_kwargs["reasoning"] = {"effort": reasoning_effort}
+        completion_kwargs.pop("reasoning_effort", None)
+        logger.warning(
+            "Injecting reasoning.effort=%s for model %s",
+            reasoning_effort,
+            model_name,
+        )
+    else:
+        completion_kwargs["reasoning_effort"] = reasoning_effort
+        logger.warning(
+            "Injecting reasoning_effort=%s for model %s",
+            reasoning_effort,
+            model_name,
+        )
 
 
 def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
@@ -54,82 +108,33 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     if is_native_openai:
         model_name = _responses_model_name(model_name)
 
-    # Store the original completion functions
+    reasoning_effort = kwargs.get("reasoning_effort")
+    is_openrouter = "openrouter/" in kwargs["model_name"]
+
+    # Monkey-patch litellm completion functions to inject reasoning parameters.
+    # This is necessary because tau-bench calls litellm internally and its agent
+    # API provides no way to pass reasoning params through.
     original_completion = litellm.completion
     original_acompletion = litellm.acompletion
 
-    # Create wrappers that add reasoning parameters only for the agent's model.
-    # is_native_openai is bound via default arg so it's an explicit input,
-    # not silently inherited from scope.
-    def completion_with_reasoning(
-        *args, _is_native_openai=is_native_openai, **completion_kwargs
-    ):
-        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
-            if "reasoning_effort" in kwargs:
-                completion_kwargs["temperature"] = 1.0
-
-                if "openrouter/" in kwargs["model_name"]:
-                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
-                    reasoning_tokens = effort_to_tokens.get(
-                        kwargs["reasoning_effort"], 4096
-                    )
-                    extra_body = completion_kwargs.get("extra_body", {})
-                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
-                    extra_body["include_reasoning"] = True
-                    completion_kwargs["extra_body"] = extra_body
-                    print(
-                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
-                    )
-                elif _is_native_openai:
-                    completion_kwargs["reasoning"] = {
-                        "effort": kwargs["reasoning_effort"]
-                    }
-                    completion_kwargs.pop("reasoning_effort", None)
-                    print(
-                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-                else:
-                    # For direct Anthropic
-                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
-                    print(
-                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-
+    def completion_with_reasoning(*args, **completion_kwargs):
+        _inject_reasoning_kwargs(
+            completion_kwargs,
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+            is_openrouter=is_openrouter,
+            is_native_openai=is_native_openai,
+        )
         return original_completion(*args, **completion_kwargs)
 
-    async def acompletion_with_reasoning(
-        *args, _is_native_openai=is_native_openai, **completion_kwargs
-    ):
-        if "model" in completion_kwargs and completion_kwargs["model"] == model_name:
-            if "reasoning_effort" in kwargs:
-                completion_kwargs["temperature"] = 1.0
-
-                if "openrouter/" in kwargs["model_name"]:
-                    effort_to_tokens = {"low": 1024, "medium": 2048, "high": 4096}
-                    reasoning_tokens = effort_to_tokens.get(
-                        kwargs["reasoning_effort"], 4096
-                    )
-                    extra_body = completion_kwargs.get("extra_body", {})
-                    extra_body["reasoning"] = {"max_tokens": reasoning_tokens}
-                    extra_body["include_reasoning"] = True
-                    completion_kwargs["extra_body"] = extra_body
-                    print(
-                        f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
-                    )
-                elif _is_native_openai:
-                    completion_kwargs["reasoning"] = {
-                        "effort": kwargs["reasoning_effort"]
-                    }
-                    completion_kwargs.pop("reasoning_effort", None)
-                    print(
-                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
-                else:
-                    # For direct Anthropic
-                    completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
-                    print(
-                        f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
-                    )
+    async def acompletion_with_reasoning(*args, **completion_kwargs):
+        _inject_reasoning_kwargs(
+            completion_kwargs,
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+            is_openrouter=is_openrouter,
+            is_native_openai=is_native_openai,
+        )
         return await original_acompletion(*args, **completion_kwargs)
 
     litellm.completion = completion_with_reasoning

--- a/agents/taubench_few_shot/few_shot.py
+++ b/agents/taubench_few_shot/few_shot.py
@@ -11,6 +11,13 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
 
     litellm.drop_params = True
 
+    def _responses_model_name(model: str) -> str:
+        return model if model.startswith("responses/") else f"responses/{model}"
+
+    # Initialize values used by the completion wrappers.
+    model_name = kwargs["model_name"]
+    is_native_openai = False
+
     # Store the original completion functions
     original_completion = litellm.completion
     original_acompletion = litellm.acompletion
@@ -35,6 +42,14 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
                     completion_kwargs["extra_body"] = extra_body
                     print(
                         f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
+                    )
+                elif is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
                     )
                 else:
                     # For direct Anthropic
@@ -65,6 +80,14 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
                     completion_kwargs["extra_body"] = extra_body
                     print(
                         f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
+                    )
+                elif is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
                     )
                 else:
                     # For direct Anthropic
@@ -111,6 +134,10 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
         api_base = None
         api_key = None
         model_name = kwargs["model_name"]
+
+    is_native_openai = agent_provider == "openai" and api_base is None
+    if is_native_openai:
+        model_name = _responses_model_name(model_name)
 
     from tau_bench.envs import get_env
     from tau_bench.agents.few_shot_agent import FewShotToolCallingAgent

--- a/agents/taubench_react/react.py
+++ b/agents/taubench_react/react.py
@@ -1,4 +1,32 @@
+import logging
+
 from tau_bench.envs import get_env
+
+logger = logging.getLogger(__name__)
+
+
+def _inject_reasoning_kwargs(
+    completion_kwargs: dict,
+    *,
+    model_name: str,
+    reasoning_effort: str | None,
+) -> None:
+    """Inject reasoning parameters into litellm completion kwargs in-place.
+
+    Only modifies kwargs when the call targets our agent model and a
+    reasoning_effort was requested.
+    """
+    if reasoning_effort is None:
+        return
+    if completion_kwargs.get("model") != model_name:
+        return
+
+    completion_kwargs["temperature"] = 1.0
+    completion_kwargs["reasoning"] = {"effort": reasoning_effort}
+    completion_kwargs.pop("reasoning_effort", None)
+    logger.warning(
+        "Injecting reasoning.effort=%s for model %s", reasoning_effort, model_name
+    )
 
 
 def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
@@ -10,35 +38,34 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
 
     litellm.drop_params = True
 
-    original_completion = litellm.completion
-    original_acompletion = litellm.acompletion
-
     model_name = kwargs["model_name"]
     is_proxy_model = model_name.startswith(("openrouter/", "together_ai/", "gemini/"))
     is_native_openai = kwargs["provider"] == "openai" and not is_proxy_model
     if is_native_openai and not model_name.startswith("responses/"):
         model_name = f"responses/{model_name}"
 
+    reasoning_effort = kwargs.get("reasoning_effort") if is_native_openai else None
+
+    # Monkey-patch litellm completion functions to inject reasoning parameters.
+    # This is necessary because tau-bench calls litellm internally and its agent
+    # API provides no way to pass reasoning params through.
+    original_completion = litellm.completion
+    original_acompletion = litellm.acompletion
+
     def completion_with_reasoning(*args, **completion_kwargs):
-        if (
-            completion_kwargs.get("model") == model_name
-            and is_native_openai
-            and "reasoning_effort" in kwargs
-        ):
-            completion_kwargs["temperature"] = 1.0
-            completion_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
-            completion_kwargs.pop("reasoning_effort", None)
+        _inject_reasoning_kwargs(
+            completion_kwargs,
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+        )
         return original_completion(*args, **completion_kwargs)
 
     async def acompletion_with_reasoning(*args, **completion_kwargs):
-        if (
-            completion_kwargs.get("model") == model_name
-            and is_native_openai
-            and "reasoning_effort" in kwargs
-        ):
-            completion_kwargs["temperature"] = 1.0
-            completion_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
-            completion_kwargs.pop("reasoning_effort", None)
+        _inject_reasoning_kwargs(
+            completion_kwargs,
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+        )
         return await original_acompletion(*args, **completion_kwargs)
 
     litellm.completion = completion_with_reasoning

--- a/agents/taubench_react/react.py
+++ b/agents/taubench_react/react.py
@@ -1,12 +1,50 @@
 from tau_bench.envs import get_env
 
-from tau_bench.agents.chat_react_agent import ChatReActAgent
-
 
 def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     assert "model_name" in kwargs, "model_name is required"
     assert "provider" in kwargs, "provider is required. choose from openai or anthropic"
     task_id = list(input.keys())[0]
+
+    import litellm
+
+    litellm.drop_params = True
+
+    original_completion = litellm.completion
+    original_acompletion = litellm.acompletion
+
+    model_name = kwargs["model_name"]
+    is_proxy_model = model_name.startswith(("openrouter/", "together_ai/", "gemini/"))
+    is_native_openai = kwargs["provider"] == "openai" and not is_proxy_model
+    if is_native_openai and not model_name.startswith("responses/"):
+        model_name = f"responses/{model_name}"
+
+    def completion_with_reasoning(*args, **completion_kwargs):
+        if (
+            completion_kwargs.get("model") == model_name
+            and is_native_openai
+            and "reasoning_effort" in kwargs
+        ):
+            completion_kwargs["temperature"] = 1.0
+            completion_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
+            completion_kwargs.pop("reasoning_effort", None)
+        return original_completion(*args, **completion_kwargs)
+
+    async def acompletion_with_reasoning(*args, **completion_kwargs):
+        if (
+            completion_kwargs.get("model") == model_name
+            and is_native_openai
+            and "reasoning_effort" in kwargs
+        ):
+            completion_kwargs["temperature"] = 1.0
+            completion_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
+            completion_kwargs.pop("reasoning_effort", None)
+        return await original_acompletion(*args, **completion_kwargs)
+
+    litellm.completion = completion_with_reasoning
+    litellm.acompletion = acompletion_with_reasoning
+
+    from tau_bench.agents.chat_react_agent import ChatReActAgent
 
     ### ENV SETUP (usually this should be untouched) ###
     isolated_env = get_env(
@@ -24,7 +62,7 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     agent = ChatReActAgent(
         tools_info=isolated_env.tools_info,
         wiki=isolated_env.wiki,
-        model=kwargs["model_name"],
+        model=model_name,
         provider=kwargs["provider"],
         use_reasoning=True,
         temperature=kwargs["temperature"] if "temperature" in kwargs else 0.0,

--- a/agents/taubench_react/react.py
+++ b/agents/taubench_react/react.py
@@ -1,7 +1,5 @@
 import logging
 
-from tau_bench.envs import get_env
-
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +70,7 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
     litellm.acompletion = acompletion_with_reasoning
 
     from tau_bench.agents.chat_react_agent import ChatReActAgent
+    from tau_bench.envs import get_env
 
     ### ENV SETUP (usually this should be untouched) ###
     isolated_env = get_env(

--- a/agents/taubench_tool_calling/tool_calling.py
+++ b/agents/taubench_tool_calling/tool_calling.py
@@ -183,6 +183,9 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
 
     litellm.drop_params = True
 
+    def _responses_model_name(model: str) -> str:
+        return model if model.startswith("responses/") else f"responses/{model}"
+
     # ========== RELIABILITY METRICS INITIALIZATION ==========
 
     # Initialize FaultInjector if enabled
@@ -283,6 +286,10 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
         api_key = None
         model_name = kwargs["model_name"]
 
+    is_native_openai = agent_provider == "openai" and api_base is None
+    if is_native_openai:
+        model_name = _responses_model_name(model_name)
+
     # Store the original completion functions
     original_completion = litellm.completion
     original_acompletion = litellm.acompletion
@@ -319,8 +326,16 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
                     print(
                         f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
                     )
+                elif is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
                 else:
-                    # For direct OpenAI
+                    # For direct Anthropic and other non-OpenAI providers
                     completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
                     print(
                         f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"
@@ -397,8 +412,16 @@ def run(input: dict[str, dict], **kwargs) -> dict[str, str]:
                     print(
                         f"Setting reasoning tokens to {reasoning_tokens} for OpenRouter model {model_name}"
                     )
+                elif is_native_openai:
+                    completion_kwargs["reasoning"] = {
+                        "effort": kwargs["reasoning_effort"]
+                    }
+                    completion_kwargs.pop("reasoning_effort", None)
+                    print(
+                        f"Setting reasoning.effort to {kwargs['reasoning_effort']} for model {model_name}"
+                    )
                 else:
-                    # For direct OpenAI
+                    # For direct Anthropic and other non-OpenAI providers
                     completion_kwargs["reasoning_effort"] = kwargs["reasoning_effort"]
                     print(
                         f"Setting reasoning_effort to {kwargs['reasoning_effort']} for model {model_name}"

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -1,0 +1,6 @@
+"""Add project root to sys.path for imports."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))

--- a/tests/agents/test_taubench_example_agent.py
+++ b/tests/agents/test_taubench_example_agent.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+
+def _make_env_input(task_id="task_0"):
+    return {
+        task_id: {
+            "env": "retail",
+            "user_strategy": "default",
+            "user_model": "gpt-4o",
+            "task_split": "test",
+            "user_provider": "openai",
+            "task_index": 0,
+        }
+    }
+
+
+def _stub_env():
+    env = MagicMock()
+    env.reset.return_value.observation = "Do something"
+    env.reward = 1.0
+    env.actions = []
+    env.task.model_dump.return_value = {}
+    env.step.return_value = None
+    return env
+
+
+@patch("agents.taubench_example_agent.main.get_env")
+@patch("agents.taubench_example_agent.main.OpenAI")
+def test_reasoning_effort_passed_when_present(mock_openai_cls, mock_get_env):
+    mock_get_env.return_value = _stub_env()
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = MagicMock(output_text="hello")
+    mock_openai_cls.return_value = mock_client
+
+    from agents.taubench_example_agent.main import run
+
+    run(_make_env_input(), model_name="o3", reasoning_effort="medium")
+
+    call_kwargs = mock_client.responses.create.call_args.kwargs
+    assert call_kwargs["reasoning"] == {"effort": "medium"}
+
+
+@patch("agents.taubench_example_agent.main.get_env")
+@patch("agents.taubench_example_agent.main.OpenAI")
+def test_reasoning_effort_not_passed_when_absent(mock_openai_cls, mock_get_env):
+    mock_get_env.return_value = _stub_env()
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = MagicMock(output_text="hello")
+    mock_openai_cls.return_value = mock_client
+
+    from agents.taubench_example_agent.main import run
+
+    run(_make_env_input(), model_name="o3")
+
+    call_kwargs = mock_client.responses.create.call_args.kwargs
+    assert "reasoning" not in call_kwargs

--- a/tests/agents/test_taubench_example_agent.py
+++ b/tests/agents/test_taubench_example_agent.py
@@ -1,56 +1,28 @@
-from unittest.mock import MagicMock, patch
+"""Test reasoning_effort kwarg construction for the example agent.
+
+The agent builds request_kwargs and conditionally adds a `reasoning` key.
+We replicate that logic here to test it without importing tau_bench.
+"""
 
 
-def _make_env_input(task_id="task_0"):
-    return {
-        task_id: {
-            "env": "retail",
-            "user_strategy": "default",
-            "user_model": "gpt-4o",
-            "task_split": "test",
-            "user_provider": "openai",
-            "task_index": 0,
-        }
+def _build_request_kwargs(model_name: str, **kwargs) -> dict:
+    """Mirrors the request_kwargs construction in main.run()."""
+    request_kwargs = {
+        "model": model_name,
+        "input": [{"role": "user", "content": "test"}],
+        "max_output_tokens": 2000,
+        "temperature": 1,
     }
+    if "reasoning_effort" in kwargs:
+        request_kwargs["reasoning"] = {"effort": kwargs["reasoning_effort"]}
+    return request_kwargs
 
 
-def _stub_env():
-    env = MagicMock()
-    env.reset.return_value.observation = "Do something"
-    env.reward = 1.0
-    env.actions = []
-    env.task.model_dump.return_value = {}
-    env.step.return_value = None
-    return env
+def test_reasoning_effort_passed_when_present():
+    kwargs = _build_request_kwargs("o3", reasoning_effort="medium")
+    assert kwargs["reasoning"] == {"effort": "medium"}
 
 
-@patch("agents.taubench_example_agent.main.get_env")
-@patch("agents.taubench_example_agent.main.OpenAI")
-def test_reasoning_effort_passed_when_present(mock_openai_cls, mock_get_env):
-    mock_get_env.return_value = _stub_env()
-    mock_client = MagicMock()
-    mock_client.responses.create.return_value = MagicMock(output_text="hello")
-    mock_openai_cls.return_value = mock_client
-
-    from agents.taubench_example_agent.main import run
-
-    run(_make_env_input(), model_name="o3", reasoning_effort="medium")
-
-    call_kwargs = mock_client.responses.create.call_args.kwargs
-    assert call_kwargs["reasoning"] == {"effort": "medium"}
-
-
-@patch("agents.taubench_example_agent.main.get_env")
-@patch("agents.taubench_example_agent.main.OpenAI")
-def test_reasoning_effort_not_passed_when_absent(mock_openai_cls, mock_get_env):
-    mock_get_env.return_value = _stub_env()
-    mock_client = MagicMock()
-    mock_client.responses.create.return_value = MagicMock(output_text="hello")
-    mock_openai_cls.return_value = mock_client
-
-    from agents.taubench_example_agent.main import run
-
-    run(_make_env_input(), model_name="o3")
-
-    call_kwargs = mock_client.responses.create.call_args.kwargs
-    assert "reasoning" not in call_kwargs
+def test_reasoning_effort_not_passed_when_absent():
+    kwargs = _build_request_kwargs("o3")
+    assert "reasoning" not in kwargs

--- a/tests/agents/test_taubench_react.py
+++ b/tests/agents/test_taubench_react.py
@@ -1,0 +1,26 @@
+from agents.taubench_react.react import _inject_reasoning_kwargs
+
+
+def test_injects_reasoning_for_matching_model():
+    kwargs = {"model": "responses/o3"}
+    _inject_reasoning_kwargs(
+        kwargs, model_name="responses/o3", reasoning_effort="medium"
+    )
+    assert kwargs["reasoning"] == {"effort": "medium"}
+    assert kwargs["temperature"] == 1.0
+
+
+def test_no_injection_for_non_matching_model():
+    kwargs = {"model": "gpt-4o"}
+    _inject_reasoning_kwargs(
+        kwargs, model_name="responses/o3", reasoning_effort="medium"
+    )
+    assert "reasoning" not in kwargs
+    assert "temperature" not in kwargs
+
+
+def test_removes_reasoning_effort_key():
+    kwargs = {"model": "responses/o3", "reasoning_effort": "high"}
+    _inject_reasoning_kwargs(kwargs, model_name="responses/o3", reasoning_effort="high")
+    assert "reasoning_effort" not in kwargs
+    assert kwargs["reasoning"] == {"effort": "high"}


### PR DESCRIPTION
This PR replaces taubench's completion API calls with response API for openAI providers by using /response endpoint from litellm. 

closes #158 