### PR TITLE
Add terminal bench 2.0

### DIFF
--- a/hal/benchmark_manager.py
+++ b/hal/benchmark_manager.py
@@ -5,6 +5,8 @@ from .benchmarks.base_benchmark import BaseBenchmark
 
 
 class BenchmarkManager:
+    EXTERNAL_BENCHMARKS = {"terminal_bench"}
+
     def __init__(
         self,
         agent_dir: str = "agent/",
@@ -33,7 +35,12 @@ class BenchmarkManager:
             "assistantbench",
             "colbench_backend_programming",
             "colbench_frontend_design",
+            "terminal_bench",
         ]
+
+    @classmethod
+    def is_external_benchmark(cls, benchmark_name: str) -> bool:
+        return benchmark_name in cls.EXTERNAL_BENCHMARKS
 
     def get_benchmark(self, benchmark_name: str) -> BaseBenchmark:
         """Get benchmark instance for given name"""
@@ -96,6 +103,10 @@ class BenchmarkManager:
             from .benchmarks.colbench import ColBenchBenchmark
 
             benchmark = ColBenchBenchmark(self.agent_dir, self.config, benchmark_name)
+        elif benchmark_name == "terminal_bench":
+            from .benchmarks.terminal_bench import TerminalBenchBenchmark
+
+            benchmark = TerminalBenchBenchmark(self.agent_dir, self.config)
         else:
             raise ValueError(f"Unknown benchmark: {benchmark_name}")
 

--- a/hal/benchmarks/base_benchmark.py
+++ b/hal/benchmarks/base_benchmark.py
@@ -71,6 +71,20 @@ class BaseBenchmark(ABC):
         os.makedirs(run_dir, exist_ok=True)
         return run_dir
 
+    def uses_external_runner(self) -> bool:
+        """Whether this benchmark delegates execution outside AgentRunner."""
+        return False
+
+    def requires_agent_entrypoint(self) -> bool:
+        """Whether hal-eval must receive --agent_dir and --agent_function."""
+        return not self.uses_external_runner()
+
+    def run_external_evaluation(self, **kwargs) -> Dict[str, Any]:
+        """Run evaluation without AgentRunner."""
+        raise NotImplementedError(
+            f"Benchmark {self.benchmark_name} does not implement an external runner."
+        )
+
     def process_results(
         self,
         agent_name: str,

--- a/hal/benchmarks/terminal_bench.py
+++ b/hal/benchmarks/terminal_bench.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Any, Dict
+
+from .base_benchmark import BaseBenchmark
+
+logger = logging.getLogger(__name__)
+
+
+class TerminalBenchBenchmark(BaseBenchmark):
+    """Terminal Bench 2.0 benchmark executed via Harbor."""
+
+    def __init__(self, agent_dir: str, config: Dict[str, Any]):
+        self.benchmark_name = "terminal_bench"
+        self.setup_script = None
+        self.requires_sandbox = False
+        self.benchmark: Dict[str, Any] = {}
+        super().__init__(
+            agent_dir,
+            config,
+            requires_sandbox=self.requires_sandbox,
+            setup_script=self.setup_script,
+        )
+
+    def uses_external_runner(self) -> bool:
+        return True
+
+    def evaluate_output(
+        self, agent_output: Dict[str, Any], run_id: str
+    ) -> Dict[str, Any]:
+        raise NotImplementedError(
+            "terminal_bench is executed through Harbor and does not use AgentRunner."
+        )
+
+    def get_metrics(self, eval_results: Dict[str, Any]) -> Dict[str, Any]:
+        total_tasks = len(eval_results)
+        if total_tasks == 0:
+            return {
+                "accuracy": 0.0,
+                "successful_tasks": [],
+                "failed_tasks": [],
+            }
+
+        successful_tasks = []
+        failed_tasks = []
+
+        for task_id, task_output in eval_results.items():
+            reward = 0.0
+            if isinstance(task_output, dict):
+                try:
+                    reward = float(task_output.get("reward", 0.0))
+                except (TypeError, ValueError):
+                    reward = 0.0
+
+            if reward > 0:
+                successful_tasks.append(task_id)
+            else:
+                failed_tasks.append(task_id)
+
+        return {
+            "accuracy": len(successful_tasks) / total_tasks,
+            "successful_tasks": successful_tasks,
+            "failed_tasks": failed_tasks,
+        }
+
+    def run_external_evaluation(self, **kwargs) -> Dict[str, Any]:
+        from hal.terminal_bench_harbor import run_terminal_bench_harbor
+
+        logger.info("Running terminal_bench through Harbor.")
+        return run_terminal_bench_harbor(benchmark=self, **kwargs)

--- a/hal/cli.py
+++ b/hal/cli.py
@@ -8,6 +8,7 @@ import time
 import importlib
 from inspect import get_annotations
 from .agent_runner import AgentRunner
+from .benchmark_manager import BenchmarkManager
 from dotenv import load_dotenv
 import sys
 import logging
@@ -250,6 +251,39 @@ def main(
 
         # get exact command used to run the evaluation from click
         run_command = " ".join(["hal-eval"] + sys.argv[1:])
+
+        if BenchmarkManager.is_external_benchmark(benchmark):
+            benchmark_manager = BenchmarkManager(agent_dir or "", config)
+            benchmark_impl = benchmark_manager.get_benchmark(benchmark)
+            if results_dir != "results":
+                benchmark_impl.base_results_dir = results_dir
+                benchmark_impl.benchmark_results_dir = os.path.join(
+                    results_dir, benchmark_impl.benchmark_name
+                )
+            results = benchmark_impl.run_external_evaluation(
+                agent_name=agent_name,
+                run_id=run_id,
+                agent_args=agent_args,
+                benchmark_args=benchmark_args,
+                max_concurrent=max_concurrent,
+                max_tasks=max_tasks,
+                continue_run=continue_run,
+                results_dir=results_dir,
+                task_ids=task_ids,
+                run_command=run_command,
+                prompt_sensitivity=prompt_sensitivity,
+                variation_strength=variation_strength,
+                variation_index=variation_index,
+                vm=vm,
+                docker=docker,
+                conda_env_name=conda_env_name,
+                upload=upload or False,
+            )
+            logger.info("Evaluation completed successfully")
+            log_results(results)
+            log_run_summary(run_id, benchmark_impl.get_run_dir(run_id))
+            return
+
         # Initialize agent runner
         logger.info("Initializing agent runner...")
         try:

--- a/hal/terminal_bench_harbor.py
+++ b/hal/terminal_bench_harbor.py
@@ -1,0 +1,592 @@
+"""Harbor-backed execution for the terminal_bench benchmark."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from hal.utils.utils import get_git_info
+from hal.utils.weave_utils import CACHED_PRICE_OVERRIDES, MODEL_PRICES_DICT
+
+logger = logging.getLogger(__name__)
+
+HARBOR_DATASET = "terminal-bench@2.0"
+HARBOR_AGENT = "claude-code"
+
+CONFIDENCE_PROMPT = """\
+You just completed a terminal-based task inside a Docker container. Please assess your confidence that the final container state passes all verification tests.
+
+Consider the following when rating your confidence:
+
+1. Did all commands exit with the expected exit codes (0 for success)?
+
+2. Did you encounter any errors, crashes, or resource issues (OOM, disk full, permission denied) that may not have been fully resolved?
+
+3. Were you able to verify the result yourself (e.g., checking that a compiled binary runs, that a service responds, that output files exist and look correct)?
+
+4. How closely did you follow the task requirements -- did you meet exact version, path, and format constraints?
+
+5. Did you have to retry or work around any failures, and are you confident the workaround produced a correct final state?
+
+6. Were there any ambiguities in the task description that forced you to make assumptions?
+
+Please provide a confidence score from 0 to 100, where:
+
+- 0-20: Very uncertain, likely incorrect -- commands failed or task requirements are probably unmet
+
+- 21-40: Low confidence -- significant issues encountered, unsure if final state is correct
+
+- 41-60: Moderate confidence -- task seemed to complete but could not fully verify all requirements
+
+- 61-80: Good confidence -- most steps succeeded and partial verification looks correct
+
+- 81-100: Very confident -- all commands succeeded, output verified, requirements clearly met
+
+Respond with ONLY a number between 0 and 100. No explanation needed."""
+
+
+def _normalize_agent_args(agent_args: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for key, value in agent_args.items():
+        if isinstance(value, bool):
+            normalized[key] = "true" if value else "false"
+        else:
+            normalized[key] = value
+    return normalized
+
+
+def _parse_iso_ts(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _stringify_message(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    if isinstance(message, list):
+        parts: list[str] = []
+        for item in message:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                else:
+                    parts.append(json.dumps(item, ensure_ascii=True))
+            else:
+                parts.append(str(item))
+        return "\n".join(part for part in parts if part)
+    if message is None:
+        return ""
+    return str(message)
+
+
+def _extract_conversation_history(trajectory: dict[str, Any]) -> list[dict[str, str]]:
+    history: list[dict[str, str]] = []
+    role_map = {
+        "user": "user",
+        "agent": "assistant",
+        "system": "system",
+    }
+
+    for step in trajectory.get("steps", []):
+        if not isinstance(step, dict):
+            continue
+        role = role_map.get(str(step.get("source", "agent")), "assistant")
+        message = _stringify_message(step.get("message")).strip()
+        if message:
+            history.append({"role": role, "content": message})
+
+    return history
+
+
+def _extract_taken_actions(trajectory: dict[str, Any]) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    for step in trajectory.get("steps", []):
+        if not isinstance(step, dict):
+            continue
+        for tool_call in step.get("tool_calls", []) or []:
+            if not isinstance(tool_call, dict):
+                continue
+            actions.append(
+                {
+                    "name": tool_call.get("function_name", ""),
+                    "arguments": tool_call.get("arguments", {}),
+                }
+            )
+    return actions
+
+
+def _extract_reward(trial_result: dict[str, Any]) -> float:
+    rewards = (trial_result.get("verifier_result") or {}).get("rewards") or {}
+    value = rewards.get("reward")
+    if value is None and rewards:
+        value = next(iter(rewards.values()))
+    try:
+        return float(value) if value is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _extract_latency_summary(trial_result: dict[str, Any]) -> tuple[dict[str, Any], float]:
+    agent_execution = trial_result.get("agent_execution") or {}
+    started = _parse_iso_ts(agent_execution.get("started_at")) or _parse_iso_ts(
+        trial_result.get("started_at")
+    )
+    finished = _parse_iso_ts(agent_execution.get("finished_at")) or _parse_iso_ts(
+        trial_result.get("finished_at")
+    )
+
+    total_time = 0.0
+    if started and finished:
+        total_time = max(0.0, (finished - started).total_seconds())
+
+    latency = {"total_time": total_time}
+    if started:
+        latency["first_call_timestamp"] = started.isoformat()
+    if finished:
+        latency["last_call_timestamp"] = finished.isoformat()
+    return latency, total_time * 1000.0
+
+
+def _resolve_model_name(trial_result: dict[str, Any]) -> str:
+    config_model = (
+        ((trial_result.get("config") or {}).get("agent") or {}).get("model_name") or ""
+    )
+    if config_model:
+        return str(config_model)
+
+    model_info = ((trial_result.get("agent_info") or {}).get("model_info") or {}).get(
+        "name"
+    )
+    provider = ((trial_result.get("agent_info") or {}).get("model_info") or {}).get(
+        "provider"
+    )
+    if provider and model_info:
+        return f"{provider}/{model_info}"
+    return str(model_info or "")
+
+
+CACHE_WRITE_PRICE_OVERRIDES: dict[str, float] = {
+    "claude-opus-4-6": 6.25 / 1e6,
+    "anthropic/claude-opus-4-6": 6.25 / 1e6,
+    "claude-opus-4-5": 6.25 / 1e6,
+    "anthropic/claude-opus-4-5": 6.25 / 1e6,
+    "claude-sonnet-4-5": 3.75 / 1e6,
+    "anthropic/claude-sonnet-4-5": 3.75 / 1e6,
+}
+
+
+def _estimate_cost(
+    trial_result: dict[str, Any], trajectory: dict[str, Any] | None = None
+) -> float:
+    agent_result = trial_result.get("agent_result") or {}
+    direct_cost = agent_result.get("cost_usd")
+    try:
+        if direct_cost is not None:
+            return float(direct_cost)
+    except (TypeError, ValueError):
+        pass
+
+    model_name = _resolve_model_name(trial_result)
+    if model_name not in MODEL_PRICES_DICT and "/" in model_name:
+        model_name = model_name.split("/", 1)[1]
+    prices = MODEL_PRICES_DICT.get(model_name)
+    if not prices:
+        return 0.0
+
+    prompt_tokens = int(agent_result.get("n_input_tokens") or 0)
+    completion_tokens = int(agent_result.get("n_output_tokens") or 0)
+    cached_read_tokens = int(agent_result.get("n_cache_tokens") or 0)
+
+    cache_write_tokens = 0
+    if trajectory:
+        final_metrics = trajectory.get("final_metrics") or {}
+        extra = final_metrics.get("extra") or {}
+        cache_write_tokens = int(extra.get("total_cache_creation_input_tokens") or 0)
+
+    fresh_prompt_tokens = max(0, prompt_tokens - cached_read_tokens - cache_write_tokens)
+
+    input_price = prices.get("prompt_tokens", 0.0)
+    output_price = prices.get("completion_tokens", 0.0)
+    cache_read_price = CACHED_PRICE_OVERRIDES.get(model_name, input_price)
+    cache_write_price = CACHE_WRITE_PRICE_OVERRIDES.get(model_name, input_price * 1.25)
+
+    return (
+        fresh_prompt_tokens * input_price
+        + cache_write_tokens * cache_write_price
+        + cached_read_tokens * cache_read_price
+        + completion_tokens * output_price
+    )
+
+
+def _load_trajectory(trial_dir: Path) -> dict[str, Any]:
+    trajectory_path = trial_dir / "agent" / "trajectory.json"
+    if not trajectory_path.exists():
+        return {}
+    try:
+        return json.loads(trajectory_path.read_text())
+    except Exception:
+        logger.warning("Failed to parse Harbor trajectory for %s", trial_dir.name)
+        return {}
+
+
+def _iter_trial_dirs(job_dir: Path) -> list[Path]:
+    return sorted(
+        path for path in job_dir.iterdir() if path.is_dir() and (path / "result.json").exists()
+    )
+
+
+def _compute_confidence_score(
+    model_name: str,
+    conversation_history: list[dict[str, str]],
+    num_actions: int,
+    exception_info: Any,
+) -> tuple[float, dict[str, Any]]:
+    """Post-hoc confidence via a single LLM self-assessment call.
+
+    Follows the same pattern as tau-bench and GAIA agents: append the
+    confidence prompt to the full conversation history and ask the model
+    for a 0-100 score.
+    """
+    import litellm
+
+    num_errors = int(exception_info is not None)
+
+    messages = copy.deepcopy(conversation_history) if conversation_history else []
+    messages.append({"role": "user", "content": CONFIDENCE_PROMPT})
+
+    try:
+        litellm.modify_params = True
+        response = litellm.completion(
+            model=model_name,
+            messages=messages,
+            temperature=0.0,
+            max_tokens=65536,
+        )
+
+        content = response.choices[0].message.content
+        if content is None:
+            raise ValueError("Model returned None content for confidence assessment")
+
+        confidence_text = content.strip()
+        numbers = re.findall(r"\d+", confidence_text)
+
+        if numbers:
+            confidence_score = float(numbers[0]) / 100.0
+            confidence_score = max(0.0, min(1.0, confidence_score))
+            logger.info(
+                "Confidence assessment: model returned '%s' -> %.2f",
+                confidence_text,
+                confidence_score,
+            )
+        else:
+            logger.warning(
+                "Could not parse confidence from '%s', using default 0.5",
+                confidence_text,
+            )
+            confidence_score = 0.5
+
+        confidence_details = {
+            "prompt": CONFIDENCE_PROMPT,
+            "model_response": confidence_text,
+            "parsed_score": confidence_score,
+            "num_actions": num_actions,
+            "num_errors": num_errors,
+            "model": model_name,
+        }
+        return confidence_score, confidence_details
+
+    except Exception as e:
+        logger.warning("Error computing confidence score: %s", e)
+        if num_actions == 0:
+            heuristic = 0.1
+        else:
+            heuristic = max(0.1, 0.9 - num_errors / max(num_actions, 1))
+
+        heuristic_details = {
+            "prompt": "ERROR: Could not call model",
+            "model_response": str(e),
+            "parsed_score": heuristic,
+            "num_actions": num_actions,
+            "num_errors": num_errors,
+            "model": model_name,
+            "fallback": True,
+        }
+        return heuristic, heuristic_details
+
+
+def _build_eval_entry(trial_result: dict[str, Any], trajectory: dict[str, Any]) -> dict[str, Any]:
+    actions = _extract_taken_actions(trajectory)
+    messages = _extract_conversation_history(trajectory)
+    cost = _estimate_cost(trial_result, trajectory)
+    exception_info = trial_result.get("exception_info")
+
+    return {
+        "reward": _extract_reward(trial_result),
+        "cost": cost,
+        "metrics": {"estimated_cost": cost},
+        "taken_actions": actions,
+        "conversation_history": messages,
+        "confidence": None,
+        "confidence_details": {
+            "num_actions": len(actions),
+            "num_errors": int(exception_info is not None),
+            "parsed_score": None,
+        },
+        "harbor_exception": exception_info,
+    }
+
+
+def _build_logging_entry(
+    task_id: str, trial_result: dict[str, Any], latency_ms: float
+) -> dict[str, Any]:
+    agent_result = trial_result.get("agent_result") or {}
+    model_name = _resolve_model_name(trial_result) or "harbor"
+    return {
+        "weave_task_id": task_id,
+        "summary": {
+            "usage": {
+                model_name: {
+                    "prompt_tokens": int(agent_result.get("n_input_tokens") or 0),
+                    "completion_tokens": int(agent_result.get("n_output_tokens") or 0),
+                    "cache_read_input_tokens": int(agent_result.get("n_cache_tokens") or 0),
+                }
+            },
+            "weave": {"latency_ms": latency_ms},
+        },
+    }
+
+
+def _write_results(
+    *,
+    benchmark,
+    run_id: str,
+    run_command: str,
+    run_dir: Path,
+    job_dir: Path,
+    agent_name: str,
+    agent_args: dict[str, Any],
+    eval_results: dict[str, Any],
+    latencies: dict[str, Any],
+    costs: dict[str, float],
+    raw_logging_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = benchmark.get_metrics(eval_results)
+    total_cost = float(sum(costs.values()))
+    total_usage: dict[str, dict[str, int]] = {}
+    for entry in raw_logging_results:
+        usage = (entry.get("summary") or {}).get("usage") or {}
+        for model_name, model_usage in usage.items():
+            total_usage.setdefault(
+                model_name,
+                {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            )
+            total_usage[model_name]["prompt_tokens"] += int(
+                model_usage.get("prompt_tokens") or 0
+            )
+            total_usage[model_name]["completion_tokens"] += int(
+                model_usage.get("completion_tokens") or 0
+            )
+            total_usage[model_name]["cache_read_input_tokens"] += int(
+                model_usage.get("cache_read_input_tokens") or 0
+            )
+
+    eval_path = run_dir / f"{run_id}.json"
+    eval_path.write_text(json.dumps(eval_results, indent=2))
+
+    payload = {
+        "metadata": {
+            "agent_args": _normalize_agent_args(agent_args),
+            "run_id": run_id,
+            "harbor_job_dir": str(job_dir),
+            "external_runner": "terminal_bench_harbor",
+        },
+        "config": {
+            "agent_name": agent_name,
+            "benchmark_name": benchmark.benchmark_name,
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "run_id": run_id,
+            "agent_args": agent_args,
+            "run_command": run_command,
+            "prompt_sensitivity": False,
+        },
+        "results": {
+            **metrics,
+            "total_cost": total_cost,
+            "latencies": latencies,
+            "costs": costs,
+        },
+        "raw_eval_results": eval_results,
+        "raw_logging_results": raw_logging_results,
+        "total_usage": total_usage,
+        "total_cost": total_cost,
+        "git_info": get_git_info(),
+    }
+
+    upload_path = run_dir / f"{run_id}_UPLOAD.json"
+    upload_path.write_text(json.dumps(payload, indent=2))
+    return payload["results"]
+
+
+def _resolve_harbor_command() -> list[str]:
+    harbor_bin = shutil.which("harbor")
+    if harbor_bin:
+        return [harbor_bin]
+    return [sys.executable, "-m", "harbor.cli.main"]
+
+
+def run_terminal_bench_harbor(
+    *,
+    benchmark,
+    agent_name: str,
+    run_id: str,
+    agent_args: dict[str, Any],
+    benchmark_args: dict[str, Any] | None = None,
+    max_concurrent: int,
+    max_tasks: int | None,
+    continue_run: bool,
+    results_dir: str,
+    task_ids: str | None,
+    run_command: str,
+    prompt_sensitivity: bool,
+    variation_strength: str,
+    variation_index: int | None,
+    vm: bool,
+    docker: bool,
+    conda_env_name: str | None,
+    upload: bool = False,
+) -> dict[str, Any]:
+    del benchmark_args, upload
+
+    if prompt_sensitivity or variation_index is not None or variation_strength != "mild":
+        raise ValueError(
+            "terminal_bench currently supports the baseline phase only."
+        )
+    if agent_args.get("enable_fault_injection") or agent_args.get(
+        "enable_structural_perturbations"
+    ):
+        raise ValueError(
+            "terminal_bench currently supports the baseline phase only."
+        )
+    if vm or docker or conda_env_name:
+        raise ValueError(
+            "terminal_bench manages execution through Harbor; do not pass --vm, --docker, or --conda_env_name."
+        )
+
+    harbor_agent_name = str(agent_args.get("harbor_agent_name") or HARBOR_AGENT)
+    model_name = str(agent_args.get("model_name") or "").strip()
+    if not model_name:
+        raise ValueError("terminal_bench requires agent arg model_name=...")
+
+    jobs_root = Path(results_dir) / benchmark.benchmark_name / "_harbor_jobs"
+    jobs_root.mkdir(parents=True, exist_ok=True)
+    job_dir = jobs_root / run_id
+
+    if continue_run:
+        if not job_dir.exists():
+            raise ValueError(f"Cannot continue Harbor job; missing job dir {job_dir}")
+        cmd = _resolve_harbor_command() + [
+            "jobs",
+            "resume",
+            "--job-path",
+            str(job_dir),
+        ]
+    else:
+        cmd = _resolve_harbor_command() + [
+            "run",
+            "--job-name",
+            run_id,
+            "--jobs-dir",
+            str(jobs_root),
+            "--dataset",
+            HARBOR_DATASET,
+            "--agent",
+            harbor_agent_name,
+            "--model",
+            model_name,
+            "--n-concurrent",
+            str(max_concurrent),
+        ]
+        if max_tasks is not None:
+            cmd.extend(["--n-tasks", str(max_tasks)])
+        if task_ids:
+            for task_id in [item.strip() for item in task_ids.split(",") if item.strip()]:
+                cmd.extend(["--task-name", task_id])
+
+    logger.info("Executing Harbor command: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    trial_dirs = _iter_trial_dirs(job_dir)
+    if not trial_dirs:
+        raise RuntimeError(f"No Harbor trial results found in {job_dir}")
+
+    compute_confidence = (
+        agent_args.get("compute_confidence") in (True, "true", "True", "1")
+    )
+
+    eval_results: dict[str, Any] = {}
+    raw_logging_results: list[dict[str, Any]] = []
+    latencies: dict[str, Any] = {}
+    costs: dict[str, float] = {}
+
+    for index, trial_dir in enumerate(trial_dirs):
+        trial_result = json.loads((trial_dir / "result.json").read_text())
+        task_id = str(
+            trial_result.get("task_name")
+            or ((trial_result.get("task_id") or {}).get("path"))
+            or index
+        )
+        trajectory = _load_trajectory(trial_dir)
+        eval_entry = _build_eval_entry(trial_result, trajectory)
+        latency_summary, latency_ms = _extract_latency_summary(trial_result)
+
+        if compute_confidence:
+            logger.info("Computing post-hoc confidence for task %s", task_id)
+            conf_score, conf_details = _compute_confidence_score(
+                model_name=model_name,
+                conversation_history=eval_entry["conversation_history"],
+                num_actions=len(eval_entry["taken_actions"]),
+                exception_info=trial_result.get("exception_info"),
+            )
+            eval_entry["confidence"] = conf_score
+            eval_entry["confidence_details"] = conf_details
+
+        eval_results[task_id] = eval_entry
+        latencies[task_id] = latency_summary
+        costs[task_id] = float(eval_entry.get("cost", 0.0) or 0.0)
+        raw_logging_results.append(_build_logging_entry(task_id, trial_result, latency_ms))
+
+    run_dir = Path(benchmark.get_run_dir(run_id))
+    return _write_results(
+        benchmark=benchmark,
+        run_id=run_id,
+        run_command=run_command,
+        run_dir=run_dir,
+        job_dir=job_dir,
+        agent_name=agent_name,
+        agent_args=agent_args,
+        eval_results=eval_results,
+        latencies=latencies,
+        costs=costs,
+        raw_logging_results=raw_logging_results,
+    )

--- a/hal/utils/weave_utils.py
+++ b/hal/utils/weave_utils.py
@@ -289,6 +289,11 @@ MODEL_PRICES_DICT = {
         "prompt_tokens": 5 / 1e6,
         "completion_tokens": 25 / 1e6,
     },
+    "claude-opus-4-6": {"prompt_tokens": 5 / 1e6, "completion_tokens": 25 / 1e6},
+    "anthropic/claude-opus-4-6": {
+        "prompt_tokens": 5 / 1e6,
+        "completion_tokens": 25 / 1e6,
+    },
     "deepseek-ai/DeepSeek-V3": {
         "prompt_tokens": 1.25 / 1e6,
         "completion_tokens": 1.25 / 1e6,
@@ -522,6 +527,8 @@ CACHED_PRICE_OVERRIDES = {
     "anthropic/claude-sonnet-4-5": 0.30 / 1e6,
     "claude-opus-4-5": 0.50 / 1e6,
     "anthropic/claude-opus-4-5": 0.50 / 1e6,
+    "claude-opus-4-6": 0.50 / 1e6,
+    "anthropic/claude-opus-4-6": 0.50 / 1e6,
     "claude-opus-4-20250514": 1.50 / 1e6,
     "anthropic/claude-opus-4-20250514": 1.50 / 1e6,
     "claude-opus-4.1-20250805": 1.50 / 1e6,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "datasets",
     "weave>=0.52.0",
+    "wandb==0.23.0",
     "gql<4",
     "huggingface-hub",
     "python-dotenv",
@@ -47,6 +48,9 @@ appworld = [
 ]
 taubench = [
     "tau-bench @ git+https://github.com/benediktstroebl/tau-bench@807e348b46a225242d5a045a8cecc690719e4b21",
+]
+terminal_bench = [
+    "harbor @ git+https://github.com/harbor-framework/harbor.git@main",
 ]
 scicode = [
   "scicode @ git+https://github.com/peterkirgis/SciCode"

--- a/reliability_eval/config.py
+++ b/reliability_eval/config.py
@@ -180,6 +180,15 @@ AGENT_CONFIGS = [
     #     "provider": "anthropic",
     #     "benchmarks": ["gaia"],
     # },
+    {
+        "name": "claude_code_opus_4_6",
+        "model_name": "anthropic/claude-opus-4-6",
+        "provider": "anthropic",
+        "benchmarks": ["terminal_bench"],
+        "extra_agent_args": {
+            "harbor_agent_name": "claude-code",
+        },
+    },
     # -------------------------------------------------------------------------
     # OpenAI Codex (OpenAI CLI agent)
     # Install: npm install -g @openai/codex
@@ -433,6 +442,14 @@ AGENT_CONFIGS = [
 # =============================================================================
 
 BENCHMARK_CONFIGS = {
+    "terminal_bench": {
+        "benchmark_name": "terminal_bench",
+        "requires_docker": False,
+        "requires_vm": False,
+        "max_concurrent": 5,
+        "external_runner": "terminal_bench_harbor",
+        "compliance_constraints": [],
+    },
     "taubench_airline": {
         "benchmark_name": "taubench_airline",
         "requires_docker": False,

--- a/reliability_eval/phases/runner.py
+++ b/reliability_eval/phases/runner.py
@@ -2,7 +2,9 @@
 
 import os
 import re
+import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -42,14 +44,17 @@ def load_environment():
         print(f"⚠️  No .env file found at {env_file.absolute()}")
 
 
-def check_api_keys():
+def check_api_keys(
+    agent_configs: list[dict] | None = None, require_wandb: bool = True
+):
     """Check that required API keys are available for configured models."""
-    # Always required
-    required_vars = ["WANDB_API_KEY"]
+    required_vars = ["WANDB_API_KEY"] if require_wandb else []
+
+    configs = agent_configs if agent_configs is not None else AGENT_CONFIGS
 
     # Check which providers are in use
-    providers_in_use = {cfg.get("provider", "openai") for cfg in AGENT_CONFIGS}
-    models_in_use = {cfg["model_name"] for cfg in AGENT_CONFIGS}
+    providers_in_use = {cfg.get("provider", "openai") for cfg in configs}
+    models_in_use = {cfg["model_name"] for cfg in configs}
 
     # Add provider-specific keys
     if "openai" in providers_in_use or any(
@@ -89,6 +94,14 @@ def check_api_keys():
 _AGENT_FUNCTION_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z_][a-zA-Z0-9_]*$")
 
 
+def _resolve_hal_eval_command() -> list[str]:
+    """Use the installed CLI when available, otherwise the current interpreter."""
+    hal_eval_bin = shutil.which("hal-eval")
+    if hal_eval_bin:
+        return [hal_eval_bin]
+    return [sys.executable, "-m", "hal.cli"]
+
+
 def _validate_agent_config(agent_config: dict) -> None:
     """Validate agent_function and agent_dir before use in subprocess commands."""
     agent_function = agent_config.get("agent_function", "")
@@ -115,18 +128,16 @@ def build_base_command(
     results_dir: str | None = None,
 ) -> list[str]:
     """Build the base hal-eval command."""
-    _validate_agent_config(agent_config)
+    requires_agent_entrypoint = not benchmark_config.get("external_runner")
+    if requires_agent_entrypoint:
+        _validate_agent_config(agent_config)
     benchmark_name = benchmark_config["benchmark_name"]
     agent_name = f"{agent_config['name']}{agent_name_suffix}"
 
     cmd = [
-        "hal-eval",
+        *_resolve_hal_eval_command(),
         "--benchmark",
         benchmark_name,
-        "--agent_dir",
-        agent_config["agent_dir"],
-        "--agent_function",
-        agent_config["agent_function"],
         "--agent_name",
         agent_name,
         "-A",
@@ -141,9 +152,20 @@ def build_base_command(
         str(max_concurrent or benchmark_config.get("max_concurrent", 1)),
     ]
 
+    if requires_agent_entrypoint:
+        cmd[3:3] = [
+            "--agent_dir",
+            agent_config["agent_dir"],
+            "--agent_function",
+            agent_config["agent_function"],
+        ]
+
     # Only add --max_tasks if explicitly set (None means run all tasks)
     if max_tasks is not None:
         cmd.extend(["--max_tasks", str(max_tasks)])
+
+    for key, value in (agent_config.get("extra_agent_args") or {}).items():
+        cmd.extend(["-A", f"{key}={value}"])
 
     # Pass reasoning_effort if specified (for models like GPT-5.2, Gemini 2.5, Claude with thinking)
     if agent_config.get("reasoning_effort"):

--- a/reliability_eval/plots/detailed.py
+++ b/reliability_eval/plots/detailed.py
@@ -765,6 +765,7 @@ def plot_calibration_by_model(
     plt.close()
 
 
+
 def plot_robustness_detailed(
     df: pd.DataFrame, all_metrics: List[ReliabilityMetrics], output_dir: Path
 ):

--- a/reliability_eval/run_reliability_eval.py
+++ b/reliability_eval/run_reliability_eval.py
@@ -345,9 +345,8 @@ Phases:
     print(f"   Conda env: {args.conda_env or 'current'}")
     print("=" * 80)
 
-    # Load environment and check keys
+    # Load environment
     load_environment()
-    check_api_keys()
 
     # Get valid combinations
     combinations = get_valid_combinations(args.benchmark)
@@ -355,6 +354,21 @@ Phases:
         print("\n❌ No valid agent-benchmark combinations found!")
         print("   Check AGENT_CONFIGS and BENCHMARK_CONFIGS")
         exit(1)
+
+    # Check only the API keys needed for the requested combinations
+    combo_agent_configs = []
+    seen_agent_names = set()
+    for agent_config, _, _ in combinations:
+        agent_name = agent_config["name"]
+        if agent_name in seen_agent_names:
+            continue
+        combo_agent_configs.append(agent_config)
+        seen_agent_names.add(agent_name)
+    require_wandb = any(
+        not benchmark_config.get("external_runner")
+        for _, benchmark_config, _ in combinations
+    )
+    check_api_keys(combo_agent_configs, require_wandb=require_wandb)
 
     print(f"\n📋 Found {len(combinations)} agent-benchmark combinations:")
     for agent, _, bench_name in combinations:


### PR DESCRIPTION
Adds terminal_bench as a new benchmark in` hal-harness`, backed by `harbor` for execution. Terminal Bench 2.0 tasks run inside Docker containers managed by Harbor, and results are normalized into HAL's standard _UPLOAD.json format for downstream reliability analysis.