### PR TITLE
fix: use Jensen-Shannon divergence for trajectory consistency (#184)

### DIFF
--- a/reliability_eval/metrics/consistency.py
+++ b/reliability_eval/metrics/consistency.py
@@ -83,7 +83,7 @@ def compute_trajectory_consistency_conditioned(
         js_divs = []
         for i in range(len(vectors)):
             for j in range(i + 1, len(vectors)):
-                js_divs.append(jensenshannon(vectors[i], vectors[j]))
+                js_divs.append(jensenshannon(vectors[i], vectors[j]) ** 2)
 
         if not js_divs:
             return np.nan

--- a/reliability_eval/metrics/consistency.py
+++ b/reliability_eval/metrics/consistency.py
@@ -83,7 +83,7 @@ def compute_trajectory_consistency_conditioned(
         js_divs = []
         for i in range(len(vectors)):
             for j in range(i + 1, len(vectors)):
-                js_divs.append(jensenshannon(vectors[i], vectors[j]) ** 2)
+                js_divs.append(jensenshannon(vectors[i], vectors[j], base=2) ** 2)
 
         if not js_divs:
             return np.nan


### PR DESCRIPTION
## Fixes #184

## Description

The paper defines Trajectory (Distributional) Consistency using Jensen-Shannon divergence:

$C_{\text{traj}} = 1 - \frac{2 \sum_{t} \sum_{i<j} \text{JSD}(i,j)}{T K (K-1)}$.

However, the implementation used `scipy.spatial.distance.jensenshannon`, which returns the Jensen-Shannon distance, i.e. the square root of the divergence.

This PR updates the calculation to use Jensen-Shannon divergence, aligning the implementation with the paper definition and avoiding underestimated consistency scores.

## Changes
* Square the output of jensenshannon(...) to obtain Jensen-Shannon divergence.
* Keep the existing pairwise averaging logic unchanged.

## Notes
This may increase the resulting consistency score compared to the previous implementation, because Jensen-Shannon distance is greater than or equal to Jensen-Shannon divergence for values in [0, 1]