### PR TITLE
fix: update trajectory consistency test for base-2 squared JSD

### DIFF
--- a/tests/reliability_eval/test_consistency_metrics.py
+++ b/tests/reliability_eval/test_consistency_metrics.py
@@ -53,10 +53,13 @@ class TestComputeTrajectoryConsistencyConditioned:
         assert C_success == pytest.approx(1.0, abs=1e-6)
 
     def test_completely_different_trajectories_give_low_consistency(self):
+        # Disjoint action support: every pairwise base-2 JS divergence is its
+        # maximum of 1.0, so mean(JSD) = 1 and C = 1 - 1 = 0.0 (lowest possible
+        # consistency).
         trajs = [["a", "a", "a"], ["b", "b", "b"], ["c", "c", "c"]]
         successes = [1, 1, 1]
         C_success = compute_trajectory_consistency_conditioned(trajs, successes)
-        assert C_success == pytest.approx(0.1674453888423023)
+        assert C_success == pytest.approx(0.0)
 
     def test_returns_nan_when_fewer_than_two_successful_runs(self):
         trajs = [["a", "b"], ["c", "d"]]


### PR DESCRIPTION
## Summary

Fixes the failing `test_completely_different_trajectories_give_low_consistency` test.

PR #185 changed `compute_trajectory_consistency_conditioned` to use the true Jensen-Shannon **divergence** — `jensenshannon(..., base=2) ** 2` — instead of the previous natural-log JS **distance** (`jensenshannon(...)`). The test's expected value for fully disjoint trajectories was never updated and still encoded the old formula (`0.1674453888423023`).

## Fix

For three trajectories with disjoint action support (`["a","a","a"]`, `["b","b","b"]`, `["c","c","c"]`), every pairwise base-2 JS divergence is its maximum of `1.0`, so `mean(JSD) = 1` and `C = 1 - 1 = 0.0` — the correct minimum consistency for "completely different" trajectories. The test now asserts `0.0`, with a comment explaining the derivation.

Verified old vs. new:
- old formula → `0.1674453888423023` (stale expected value)
- new formula → `0.0`

## Testing

`tests/reliability_eval/test_consistency_metrics.py` — 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)